### PR TITLE
References to ports of services centralised

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,10 @@
+EXPRESS_JS_PORT=80
+XML_RPC_PORT=9090
+GRAPHQL_PORT=4000
 JWT_SECRET=access
 MONGO_LOCAL_CONN_URL=mongodb://localhost:27017/node-dvws
 MONGO_DB_NAME=dvws-user-auth
 SQL_LOCAL_CONN_URL=localhost
 SQL_DB_NAME=dvws_sqldb
-SQL_username=root
-SQL_password=mysecretpassword
+SQL_USERNAME=root
+SQL_PASSWORD=mysecretpassword

--- a/app.js
+++ b/app.js
@@ -56,8 +56,8 @@ app.use('/api', routes(router));
 
 
   
-app.listen(80, () => {
-    console.log(`🚀 API listening at 80, go to http://dvws.local (127.0.0.1)`);
+app.listen(process.env.EXPRESS_JS_PORT, () => {
+    console.log(`🚀 API listening at http://dvws.local${process.env.EXPRESS_JS_PORT == 80 ? "" : ":" + process.env.EXPRESS_JS_PORT } (127.0.0.1)`);
   });
 
 
@@ -81,7 +81,7 @@ const server = new ApolloServer({
   }, });
 
 
-server.listen().then(({ url }) => {
+server.listen({ port: process.env.GRAPHQL_PORT }).then(({ url }) => {
     console.log(`🚀 GraphQL Server ready at ${url}`);
   });;
 

--- a/models/passphrase.js
+++ b/models/passphrase.js
@@ -2,8 +2,8 @@ const Sequelize = require('sequelize');
 require('dotenv').config();
 
 const connHost = process.env.SQL_LOCAL_CONN_URL;
-const connUser = process.env.SQL_username;
-const connPass = process.env.SQL_password;
+const connUser = process.env.SQL_USERNAME;
+const connPass = process.env.SQL_PASSWORD;
 const connDB = process.env.SQL_DB_NAME;
 
 const sequelize = new Sequelize(connDB, connUser, connPass, {

--- a/rpc_server.js
+++ b/rpc_server.js
@@ -2,7 +2,7 @@ var xmlrpc = require('xmlrpc');
 var needle = require('needle');
 
 // Creates an XML-RPC server to listen to XML-RPC method calls
-var server = xmlrpc.createServer({ port: 9090, path: '/xmlrpc' })
+var server = xmlrpc.createServer({ port: process.env.XML_RPC_PORT, path: '/xmlrpc' })
 // Handle methods not found
 server.on('NotFound', function (method, params) {
   console.log('Method ' + method + ' does not exist');
@@ -44,5 +44,5 @@ server.on('dvws.CheckUptime', function (err, params, callback) {
   callback(null, get_result)
 })
 
-console.log('XML-RPC server listening on port 9090')
+console.log(`🚀 XML-RPC server listening on port ${process.env.XML_RPC_PORT}`)
 

--- a/startup_script.js
+++ b/startup_script.js
@@ -7,8 +7,8 @@ const User = require('./models/users');
 
 
 const connHost = process.env.SQL_LOCAL_CONN_URL;
-const connUser = process.env.SQL_username;
-const connPass = process.env.SQL_password;
+const connUser = process.env.SQL_USERNAME;
+const connPass = process.env.SQL_PASSWORD;
 const connUri = process.env.MONGO_LOCAL_CONN_URL;
 
 const sequelize = new Sequelize('dvws_sqldb', connUser, connPass, {


### PR DESCRIPTION
### Overview
My machine would complain when running the NPM server due to Linux requiring root permissions when listening on a port below 1024. To resolve this, I had to alter the project code to change the port number that ExpressJS leveraged. This ticket aims to make this resolution easier for future users by extracting and centralising the ports defined for the following three services: ExpressJS, XML RPC, and GraphQL.

### Implementation Details

- The .env file was updated to contain three entries for the ports of the three services.
- I updated the references from the hardcoded values to the ones stored within .env 

### Replication Steps

- Alter the port numbers to values of your choosing
- Execute _npm start_ and confirm:
  - The output from the command reflects the ports you chose.
  - The services are listening on the ports you chose.

### Questions/Issues
- It could be worth standardising the command output for the three services? 
  - For instance, choose the following to uniform all three: _🚀 XYZ server listening on port XYZ_
  - Additionally, the ExpressJS line says API, is this correct? I thought it also hosted the app?
- The config.xml file references a hardcoded value for XML RPC. I couldn't alter this as it's not a JavaScript file. I can't think of a way to make this dynamic off my head. Would be worth brainstorming...
